### PR TITLE
Add build2 alternative file extensions

### DIFF
--- a/buildfile.sublime-syntax
+++ b/buildfile.sublime-syntax
@@ -2,11 +2,22 @@
 ---
 name: build2 buildfile
 file_extensions:
-  - root.build
-  - export.build
   - bootstrap.build
+  - bootstrap.build2
   - config.build
+  - config.build2
+  - export.build
+  - export.build2
+  - root.build
+  - root.build2
+  - src-root.build
+  - src-root.build2
+  - out-root.build
+  - out-root.build2
+  - pre-bdep-sync.build
+  - pre-bdep-sync.build2
   - buildfile
+  - build2file
 scope: source.build2.buildfile
 contexts:
   main:


### PR DESCRIPTION
Add alternative file extensions based on https://github.com/build2/build2/blob/87a7253a3bd82b59063172f3799b0a5587e7b2a5/libbuild2/file.cxx#L56-L70